### PR TITLE
getDoc: added '?attachments='

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,9 +197,9 @@ Wrapper for [PUT /db-name](http://wiki.apache.org/couchdb/HTTP_database_API#PUT_
 
 Wrapper for [DELETE /db-name](http://wiki.apache.org/couchdb/HTTP_database_API#DELETE).
 
-### db.getDoc(id, [rev])
+### db.getDoc(id, [rev], [attachments])
 
-Wrapper for [GET /db-name/doc-id\[?rev=\]](http://wiki.apache.org/couchdb/HTTP_Document_API#GET). Fetches a document with a given `id` and optional `rev` from the database.
+Wrapper for [GET /db-name/doc-id\[?rev=\]\[&attachments=\]](http://wiki.apache.org/couchdb/HTTP_Document_API#GET). Fetches a document with a given `id` and optional `rev` and/or `attachments` from the database.
 
 ### db.saveDoc(id, doc)
 

--- a/lib/couchdb.js
+++ b/lib/couchdb.js
@@ -377,18 +377,39 @@ Db.prototype.remove = function(cb) {
   return this.request('DELETE', '', cb);
 };
 
-Db.prototype.getDoc = function(id, rev, cb) {
+Db.prototype.getDoc = function(id, rev, attachments, cb) {
   var request = {
     path: '/'+id
   };
-  if (!cb && typeof rev === 'function') {
+  
+  if (!cb && !attachments && typeof rev === 'function') {
     cb = rev;
+    rev = undefined;
+  } else if (!cb && typeof attachments === 'function') {
+    cb = attachments;
+    if (typeof rev === 'boolean') {
+      attachments = rev;
+      rev = undefined;
+    } else {
+      attachments = undefined;
+    }
   }
-  else {
+  
+  if (rev) {
     request.query = {
       'rev': rev
     };
   }
+  if (attachments) {
+    if(!request.query) {
+      request.query = {};
+    }
+    request.query.attachments = attachments;
+    request.headers = {
+      Accept: "application/json"
+    }
+  }
+  
   return this.request(request, cb);
 };
 


### PR DESCRIPTION
Hi!

I added support for ['?attachments='](http://wiki.apache.org/couchdb/HTTP_Document_API#Getting_Attachments_With_a_Document) to getDoc.

I realize adding an options-object as parameter would be better than two optional parameters, but it would break programs already using the function with the rev parameter.

I would also like to add the option for ['?atts_since='](http://wiki.apache.org/couchdb/HTTP_Document_API#Getting_Only_Changed_Attachments) some time soon, but that would definitely require an options-parameter of some sort.

Also, I'm new to Javascript and GitHub. If i did something in the wrong way, constructive criticism would be very helpful :)

Kind Regards,
Daniel
