### PR TITLE
Use `keys` in query

### DIFF
--- a/lib/couchdb.js
+++ b/lib/couchdb.js
@@ -77,7 +77,7 @@ exports.toJSON = function(data) {
 // Encode only key, startkey and endkey as JSON
 exports.toQuery = function(query) {
   for (var k in query) {
-    if (['key', 'startkey', 'endkey'].indexOf(k) != -1) {
+    if (['key', 'keys', 'startkey', 'endkey'].indexOf(k) != -1) {
       query[k] = JSON.stringify(query[k]);
     } else {
       query[k] = String(query[k]);


### PR DESCRIPTION
This solved [the issue about not being able to use `{ keys: [...] }` in a query](https://github.com/felixge/node-couchdb/issues/41).
