### PR TITLE
Improve output when receiving non-JSON from server

### DIFF
--- a/lib/couchdb.js
+++ b/lib/couchdb.js
@@ -226,7 +226,7 @@ exports.createClient = function(port, host, user, pass, maxListeners, secure) {
             json = JSON.parse(buffer);
           } catch (e) {
             cbFired = true;
-            return cb && cb(new Error('invalid json: '+json+" "+e.message));
+            return cb && cb(new Error('invalid json: "'+buffer+'". '+e.message));
           }
 
           if ('error' in json) {


### PR DESCRIPTION
I'm getting exceptions, apparently caused by the server returning non-JSON responses. In order to figure the root cause I need to see what the server's response is (I imagine it's a human-readable string describing the auth/connectivity/whatever issue).
This fix adds the raw response to the error output so that it's available post-mortem.
