### PR TITLE
Throws error on node v0.10: TypeError: n must be a positive number

### DIFF
--- a/lib/couchdb.js
+++ b/lib/couchdb.js
@@ -188,7 +188,9 @@ exports.createClient = function(port, host, user, pass, maxListeners, secure) {
       i,
       n;
 
-    request.setMaxListeners(maxListeners);
+    if (!isNaN(maxListeners)) {
+        request.setMaxListeners(maxListeners);
+    }
 
     request.on('error', onError);
     request.on('close', onClose);


### PR DESCRIPTION
$ make test
node test/test-attachment.js
node test/test-changes.js
http.createClient is deprecated. Use `http.request` instead.
node test/test-client.js

events.js:49
    throw TypeError('n must be a positive number');
          ^
TypeError: n must be a positive number
    at TypeError (<anonymous>)
    at ClientRequest.EventEmitter.setMaxListeners (events.js:49:11)
    at couchClient._queueRequest (/Users/mandric/tmp/node-couchdb/lib/couchdb.js:191:13)
    at Client.request (/Users/mandric/tmp/node-couchdb/lib/couchdb.js:324:15)
    at Client.uuids (/Users/mandric/tmp/node-couchdb/lib/couchdb.js:344:15)
    at Object.<anonymous> (/Users/mandric/tmp/node-couchdb/test/test-client.js:113:4)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
node test/test-db.js
node test/test-request.js
node test/test-to-query.js
make: **\* [test] Error 1
