### PR TITLE
fix request to couch

### DIFF
--- a/lib/couchdb.js
+++ b/lib/couchdb.js
@@ -217,7 +217,7 @@ exports.createClient = function(port, host, user, pass, maxListeners, secure) {
         })
         .on('end', function() {
           var json;
-          httpAgent.sockets[host + ':' + port][0].emit("agentRemove");
+          httpAgent.sockets[host + ':' + port + '::'][0].emit("agentRemove");
 
           if(options.responseEncoding == 'binary') {
             cbFired = true;
@@ -673,10 +673,13 @@ Db.prototype.changesStream = function(query, options) {
 
   var
     stream = new process.EventEmitter(),
-    client = http.createClient(this.client.port, this.client.host, this.client.port == 443),
-    path = '/'+this.name+'/_changes?'+exports.toQuery(query),
-    headers = this.client._authorizationHeaders({'Host': this.client.host}),
-    request = client.request('GET', path, headers),
+    request = http.request({
+    	port: 		this.client.port, 
+    	hostname: this.client.host,
+    	path: 		'/' + this.name + '/_changes?' + exports.toQuery(query),
+    	headers: 	this.client._authorizationHeaders({'Host': this.client.host}), 
+    	method: 	'GET',
+    }),
     buffer = '';
 
   request.setTimeout(options.timeout);


### PR DESCRIPTION
Hi, using etherpad, which use ueberDB, which use node-couchdb, I'va encounter some problem with this dependency.

I was using node 0.12 & couchDB 1.6.1.
This fix is doing the job for me, and tests are also passing.


I also refactor the http.request part, as node was telling me that `http.createClient` was deprecated :smile: 